### PR TITLE
Fixes camera  preview aspect ratio distortion

### DIFF
--- a/lib/ar_camera.dart
+++ b/lib/ar_camera.dart
@@ -47,15 +47,12 @@ class _ArCameraViewState extends State<ArCamera> {
       );
     }
     if (isCameraAuthorize && isCameraInitialize) {
-      return SizedBox(
-        width: double.infinity,
-        height: double.infinity,
-        child: AspectRatio(
-          aspectRatio: 1 / controller!.value.aspectRatio,
-          child: CameraPreview(controller!),
+      return SizedBox.expand(
+        child: FittedBox(
+          fit: BoxFit.cover,
+          child: SizedBox(width: 100, child: CameraPreview(controller!)),
         ),
-      );
-    }
+      );    }
     return const Text('Camera error');
   }
 


### PR DESCRIPTION
BoxFit.cover together with SizedBox.expanded will scale the CameraPreview widget to cover the size of the parent widget.